### PR TITLE
Content management

### DIFF
--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -3,12 +3,9 @@ class ContentsController < ApplicationController
 
   # GET /contents
   def index
-    render json: {
-      contents: Content.all,
-      content_metadata: ContentMetadatum.all,
-      content_audios: ContentAudio.all,
-      content_resources: ContentResource.all
-    }
+    @contents = Content.all
+
+    render json: @contents
   end
 
   # GET /contents/1

--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -3,14 +3,22 @@ class ContentsController < ApplicationController
 
   # GET /contents
   def index
-    @contents = Content.all
-
-    render json: @contents
+    render json: {
+      contents: Content.all,
+      content_metadata: ContentMetadatum.all,
+      content_audios: ContentAudio.all,
+      content_resources: ContentResource.all
+    }
   end
 
   # GET /contents/1
   def show
-    render json: @content
+    render json: {
+      contents: @content,
+      content_metadata: @content_metadata,
+      content_audios: @content_audios,
+      content_resources: @content_resources
+    }
   end
 
   # POST /contents
@@ -39,13 +47,17 @@ class ContentsController < ApplicationController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_content
-      @content = Content.find(params[:id])
-    end
 
-    # Only allow a trusted parameter "white list" through.
-    def content_params
-      params.require(:content).permit(:category_id, :daisy_format_id, :title)
-    end
+  # Use callbacks to share common setup or constraints between actions.
+  def set_content
+    @content = Content.find(params[:id])
+    @content_metadata = ContentMetadatum.where(content_id: params[:id])
+    @content_audios = ContentAudio.where(content_id: params[:id])
+    @content_resources = ContentResource.where(content_id: params[:id])
+  end
+
+  # Only allow a trusted parameter "white list" through.
+  def content_params
+    params.require(:content).permit(:category_id, :daisy_format_id, :title)
+  end
 end

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -1,4 +1,15 @@
 class Content < ApplicationRecord
   belongs_to :category
   belongs_to :daisy_format
+  has_many :content_audios, dependent: :destroy
+  has_many :content_metadata, dependent: :destroy
+  has_many :content_resources, dependent: :destroy
+
+  before_destroy :ensure_safe
+
+  private
+
+  def ensure_safe
+    UserContent.where(content_id: id).empty?
+  end
 end

--- a/app/models/content_list.rb
+++ b/app/models/content_list.rb
@@ -1,4 +1,4 @@
 class ContentList < ApplicationRecord
-    has_many :primary_user_contents, :class_name => 'UserContent', :foreign_key => 'content_list_id'
-    has_many :secondary_user_contents, :class_name => 'UserContent', :foreign_key => 'content_list_v1_id'
+  has_many :primary_user_contents, class_name: 'UserContent', foreign_key: 'content_list_id'
+  has_many :secondary_user_contents, class_name: 'UserContent', foreign_key: 'content_list_v1_id'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,9 +5,9 @@ Rails.application.routes.draw do
   resources :question_inputs
   resources :questions
   resources :question_types
-  resources :content_resources
-  resources :content_metadata
-  resources :content_audios
+  resources :content_resources, except: %i[update show index]
+  resources :content_metadata, except: %i[update show index]
+  resources :content_audios, except: %i[update show index]
   resources :user_contents
   resources :states
   resources :content_lists

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   resources :question_inputs
   resources :questions
   resources :question_types
+  # TODO: decide if deletes should be prohibited as well.
   resources :content_resources, except: %i[update show index]
   resources :content_metadata, except: %i[update show index]
   resources :content_audios, except: %i[update show index]

--- a/db/migrate/20190220190600_create_user_contents.rb
+++ b/db/migrate/20190220190600_create_user_contents.rb
@@ -3,8 +3,8 @@ class CreateUserContents < ActiveRecord::Migration[5.2]
     create_table :user_contents do |t|
       t.references :user, foreign_key: true
       t.references :content, foreign_key: true
-      t.references :content_list, foreign_key: true
-      t.references :content_list_v1, foreign_key: true, default: 3
+      t.references :content_list
+      t.references :content_list_v1, default: 3
       t.integer :return, null: false
       t.integer :returned, null: false, default: 0
       t.datetime :return_at, default: nil


### PR DESCRIPTION
This pull request implements the content view refactor, the routing and the cascading deletion tasks in the project backlog. I also found there was an issue with my earlier implementation of the double reference in UserContent which I fixed. I've done some limited testing locally and found that the cascading deletion works and I've ensured that foreign key constraints indeed render the deletion of contents impossible if they are in a user's bookshelf. The ensure_safe method I've added to the content model might in fact be redundant for this reason, but I left it in just in case.