### PR TITLE
Rename column in announcements

### DIFF
--- a/app/controllers/announcements_controller.rb
+++ b/app/controllers/announcements_controller.rb
@@ -46,6 +46,6 @@ class AnnouncementsController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def announcement_params
-      params.require(:announcement).permit(:type, :priority)
+      params.require(:announcement).permit(:category, :priority)
     end
 end

--- a/db/migrate/20190508030826_rename_column_type_to_category_in_announcements.rb
+++ b/db/migrate/20190508030826_rename_column_type_to_category_in_announcements.rb
@@ -1,0 +1,5 @@
+class RenameColumnTypeToCategoryInAnnouncements < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :announcements, :type, :category
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_21_183224) do
+ActiveRecord::Schema.define(version: 2019_05_08_030826) do
 
   create_table "announcement_audios", force: :cascade do |t|
     t.integer "announcement_text_id"
@@ -32,7 +32,7 @@ ActiveRecord::Schema.define(version: 2019_02_21_183224) do
   end
 
   create_table "announcements", force: :cascade do |t|
-    t.text "type"
+    t.text "category"
     t.text "priority", default: "LOW", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/test/controllers/announcements_controller_test.rb
+++ b/test/controllers/announcements_controller_test.rb
@@ -12,7 +12,7 @@ class AnnouncementsControllerTest < ActionDispatch::IntegrationTest
 
   test "should create announcement" do
     assert_difference('Announcement.count') do
-      post announcements_url, params: { announcement: { priority: @announcement.priority, type: @announcement.type } }, as: :json
+      post announcements_url, params: { announcement: { priority: @announcement.priority, category: @announcement.category } }, as: :json
     end
 
     assert_response 201
@@ -24,7 +24,7 @@ class AnnouncementsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should update announcement" do
-    patch announcement_url(@announcement), params: { announcement: { priority: @announcement.priority, type: @announcement.type } }, as: :json
+    patch announcement_url(@announcement), params: { announcement: { priority: @announcement.priority, category: @announcement.category } }, as: :json
     assert_response 200
   end
 

--- a/test/fixtures/announcements.yml
+++ b/test/fixtures/announcements.yml
@@ -1,9 +1,9 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  type: MyText
+  category: MyText
   priority: MyText
 
 two:
-  type: MyText
+  category: MyText
   priority: MyText


### PR DESCRIPTION
I noticed this issue while trying to seed the database with test data. `type` is a reserved keyword and shall thus not be used in active records.