### PR TITLE
No defaults for text columns

### DIFF
--- a/db/migrate/20190111182636_create_announcements.rb
+++ b/db/migrate/20190111182636_create_announcements.rb
@@ -2,7 +2,7 @@ class CreateAnnouncements < ActiveRecord::Migration[5.2]
   def change
     create_table :announcements do |t|
       t.text :type
-      t.text :priority, null: false, default: 'LOW'
+      t.text :priority, null: false
 
       t.timestamps
     end

--- a/db/migrate/20190221165021_create_content_resources.rb
+++ b/db/migrate/20190221165021_create_content_resources.rb
@@ -2,9 +2,9 @@ class CreateContentResources < ActiveRecord::Migration[5.2]
   def change
     create_table :content_resources do |t|
       t.references :content, foreign_key: true
-      t.text :file_name, null: false, default: ''
+      t.text :file_name, null: false
       t.integer :bytes, null: false, default: 0
-      t.text :mime_type, null: false, default: 'unknown'
+      t.text :mime_type, null: false
 
       t.timestamps
     end

--- a/db/migrate/20190221181516_create_question_inputs.rb
+++ b/db/migrate/20190221181516_create_question_inputs.rb
@@ -6,7 +6,7 @@ class CreateQuestionInputs < ActiveRecord::Migration[5.2]
       t.integer :text_numeric, default: nil
       t.integer :text_alphanumeric, default: nil
       t.integer :audio, default: nil
-      t.text :default_value, default: nil
+      t.text
 
       t.timestamps
     end

--- a/db/migrate/20190221181516_create_question_inputs.rb
+++ b/db/migrate/20190221181516_create_question_inputs.rb
@@ -6,7 +6,7 @@ class CreateQuestionInputs < ActiveRecord::Migration[5.2]
       t.integer :text_numeric, default: nil
       t.integer :text_alphanumeric, default: nil
       t.integer :audio, default: nil
-      t.text
+      t.text :default_value
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -33,7 +33,7 @@ ActiveRecord::Schema.define(version: 2019_05_08_030826) do
 
   create_table "announcements", force: :cascade do |t|
     t.text "category"
-    t.text "priority", default: "LOW", null: false
+    t.text "priority", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -70,9 +70,9 @@ ActiveRecord::Schema.define(version: 2019_05_08_030826) do
 
   create_table "content_resources", force: :cascade do |t|
     t.integer "content_id"
-    t.text "file_name", default: "", null: false
+    t.text "file_name", null: false
     t.integer "bytes", default: 0, null: false
-    t.text "mime_type", default: "unknown", null: false
+    t.text "mime_type", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["content_id"], name: "index_content_resources_on_content_id"


### PR DESCRIPTION
A requirement to support MySQL which apparently does not allow defaults for text columns.

Please try to remember (if I forget about it) that we shall handle the defaults from the controller instead.